### PR TITLE
Improved parsing of response in latex format

### DIFF
--- a/app/expression_utilities.py
+++ b/app/expression_utilities.py
@@ -278,13 +278,15 @@ def substitute_input_symbols(exprs, params):
     return exprs
 
 
-def find_matching_parenthesis(string, index):
+def find_matching_parenthesis(string, index, delimiters=None):
     depth = 0
+    if delimiters == None:
+        delimiters = ('(', ')')
     for k in range(index, len(string)):
-        if string[k] == '(':
+        if string[k] == delimiters[0]:
             depth += 1
             continue
-        if string[k] == ')':
+        if string[k] == delimiters[1]:
             depth += -1
             if depth == 0:
                 return k

--- a/app/preview_utilities.py
+++ b/app/preview_utilities.py
@@ -7,6 +7,7 @@ from latex2sympy2 import latex2sympy
 from .expression_utilities import (
     extract_latex,
     SymbolDict,
+    find_matching_parenthesis,
 )
 
 class Params(TypedDict):
@@ -65,3 +66,20 @@ def parse_latex(response: str, symbols: SymbolDict) -> str:
 
     except Exception as e:
         raise ValueError(str(e))
+
+def sanitise_latex(response):
+    index = 0
+    response = response.replace('~',' ')
+    processed_response = []
+    while index < len(response):
+        mathrm_start = response.find(r"\mathrm{", index)
+        if mathrm_start > -1:
+            processed_response.append(response[index:mathrm_start])
+            mathrm_end = find_matching_parenthesis(response, mathrm_start+1, delimiters=('{','}'))
+            inside_mathrm = response[(mathrm_start+len(r"\mathrm{")):mathrm_end]
+            processed_response.append(inside_mathrm)
+            index = mathrm_end+1
+        else:
+            processed_response.append(response[index:])
+            index = len(response)
+    return "".join(processed_response)

--- a/app/quantity_comparison_preview.py
+++ b/app/quantity_comparison_preview.py
@@ -5,11 +5,13 @@ from .expression_utilities import (
     convert_absolute_notation,
     create_expression_set,
     create_sympy_parsing_params,
+    find_matching_parenthesis,
     latex_symbols,
     parse_expression,
     substitute_input_symbols,
     SymbolDict,
     sympy_symbols,
+    sympy_to_latex,
 )
 
 from .preview_utilities import (
@@ -17,11 +19,33 @@ from .preview_utilities import (
     Preview,
     Result,
     extract_latex,
-    parse_latex
+    parse_latex,
+    sanitise_latex,
 )
 
 from .slr_quantity import SLR_quantity_parser
 from .slr_quantity import SLR_quantity_parsing as quantity_parsing
+
+def fix_exponents(response):
+    processed_response = []
+    exponents_notation = ['^','**']
+    for notation in exponents_notation:
+        index = 0
+        while index < len(response):
+            exponent_start = response.find(notation, index)
+            if exponent_start > -1:
+                exponent_start += len(notation)
+                processed_response.append(response[index:exponent_start])
+                exponent_end = find_matching_parenthesis(response, exponent_start, delimiters=('{','}'))
+                inside_exponent = '('+response[(exponent_start+1):exponent_end]+')'
+                processed_response.append(inside_exponent)
+                index = exponent_end+1
+            else:
+                processed_response.append(response[index:])
+                break
+        response = "".join(processed_response)
+        processed_response = []
+    return response
 
 def preview_function(response: str, params: Params) -> Result:
     """
@@ -51,15 +75,30 @@ def preview_function(response: str, params: Params) -> Result:
     latex_out = ""
     sympy_out = ""
 
+
     try:
         if params.get("is_latex", False):
-            response = parse_latex(response, symbols)
+            response = sanitise_latex(response)
+            response = fix_exponents(response)
 
         quantity_parser = SLR_quantity_parser(params)
         res_parsed = quantity_parsing(response, params, quantity_parser, "response")
 
-        latex_out = res_parsed.latex_string
-        sympy_out = response
+        if params.get("is_latex", False):
+            value = res_parsed.value
+            separator = ""
+            value_latex = ""
+            if value is not None:
+                value_string = parse_latex(value.content_string(), symbols)
+                value = parse_expression(value_string, params)
+                separator = "~"
+                value_latex = sympy_to_latex(value, symbols)
+            unit_latex = res_parsed.unit_latex_string if res_parsed.unit_latex_string is not None else ""
+            latex_out = value_latex+separator+unit_latex
+            sympy_out = str(value)+" "+res_parsed.unit.content_string()
+        else:
+            latex_out = res_parsed.latex_string
+            sympy_out = response
 
     except SyntaxError as e:
         raise ValueError("Failed to parse Sympy expression") from e

--- a/app/quantity_comparison_preview_tests.py
+++ b/app/quantity_comparison_preview_tests.py
@@ -51,6 +51,16 @@ class TestPreviewFunction():
             latex = value_latex+"~"+unit_latex
         assert result["latex"] == latex
 
+    def test_handwritten_input(self):
+        params = {
+            "is_latex": True,
+            "physical_quantity": True,
+            "elementary_functions": True,
+        }
+        response = "\\sqrt{162} \\mathrm{~N} / \\mathrm{m}^{2}"
+        result = preview_function(response, params)["preview"]
+        assert result["latex"] == r"\sqrt{162}~\frac{\mathrm{newton}}{\mathrm{metre}^{(2)}}" # TODO: Fix so that unnecessary parenthesis are simplified away
+        assert result["sympy"] == "sqrt(162) newton / metre^(2)"
 
 if __name__ == "__main__":
     pytest.main(['-sk not slow', "--tb=line", os.path.abspath(__file__)])

--- a/app/slr_quantity.py
+++ b/app/slr_quantity.py
@@ -119,12 +119,11 @@ class PhysicalQuantity:
     def _value_latex(self, parameters):
         if self.value is not None:
             preview_parameters = {**parameters}
-#            if "rtol" in preview_parameters.keys():
-#                del preview_parameters["rtol"]
             if "rtol" not in preview_parameters.keys():
                 preview_parameters.update({"rtol": 1e-12})
-            value_latex = symbolic_preview(self.value.original_string(), preview_parameters)
-            value_latex = symbolic_preview(self.value.original_string(), preview_parameters)["preview"]["latex"]
+            original_string = self.value.original_string()
+            value = symbolic_preview(original_string, preview_parameters)
+            value_latex = value["preview"]["latex"]
             return value_latex
         return None
 


### PR DESCRIPTION
1: Removes \mathrm{...} wrapper and replaces ~ with space 2: Changes {...} to (...) in exponents
3: 1 and 2 together means that the response can be parsed as a quantity.
    - the value is then extracted from the quantity and converted from latex to sympy code
    - the sympy code is parsed as a symbolic expression
    - the symbolic expression is used to generate output for the value part