### PR TITLE
Fixed issue with parsing quantities without spacing with natural syntax

### DIFF
--- a/app/criteria_utilities.py
+++ b/app/criteria_utilities.py
@@ -22,3 +22,17 @@ class Criterion:
     def __setitem__(self, key, value):
         self.feedback.update({key: value})
         return
+
+
+class CriterionNode:
+
+    def __init__(self, definition, output, actions):
+        self.definition = definition
+        self.result = None
+        self.output = output,
+        self.actions = actions
+
+    def check(self, inputs):
+        if self.result is None:
+            self.result = check_criteria(definition, inputs)
+            

--- a/app/quantity_comparison_preview.py
+++ b/app/quantity_comparison_preview.py
@@ -75,21 +75,19 @@ def preview_function(response: str, params: Params) -> Result:
     latex_out = ""
     sympy_out = ""
 
+    quantity_parser = SLR_quantity_parser(params)
 
     try:
         if params.get("is_latex", False):
             response = sanitise_latex(response)
             response = fix_exponents(response)
-
-        quantity_parser = SLR_quantity_parser(params)
-        res_parsed = quantity_parsing(response, params, quantity_parser, "response")
-
-        if params.get("is_latex", False):
+            res_parsed = quantity_parsing(response, params, quantity_parser, "response")
             value = res_parsed.value
             unit = res_parsed.unit
             value_latex = ""
             if value is not None:
                 value_string = parse_latex(value.content_string(), symbols)
+                params.update({"is_latex": False})
                 value = parse_expression(value_string, params)
                 value_latex = sympy_to_latex(value, symbols)
             separator_latex = ""
@@ -103,6 +101,7 @@ def preview_function(response: str, params: Params) -> Result:
             unit_sympy = res_parsed.unit.content_string() if unit is not None else ""
             sympy_out = value_sympy+separator_sympy+unit_sympy
         else:
+            res_parsed = quantity_parsing(response, params, quantity_parser, "response")
             latex_out = res_parsed.latex_string
             sympy_out = response
 

--- a/app/quantity_comparison_preview_tests.py
+++ b/app/quantity_comparison_preview_tests.py
@@ -51,16 +51,20 @@ class TestPreviewFunction():
             latex = value_latex+"~"+unit_latex
         assert result["latex"] == latex
 
-    def test_issue_with_sqrt(self):
+    @pytest.mark.parametrize("response,preview_latex,preview_sympy",
+        [
+            ("sin(123)", r"\sin{\left(123 \right)}", "sin(123)"),
+            ("sqrt(162)", r"\sqrt{162}", "sqrt(162)"),
+        ]
+    )
+    def test_issue_with_function_name_that_can_be_compound_unit(self, response, preview_latex, preview_sympy):
         params = {
-            "is_latex": True,
             "physical_quantity": True,
             "elementary_functions": True,
         }
-        response = "\\sqrt{162}"
         result = preview_function(response, params)["preview"]
-        assert result["latex"] == r'\sqrt{162}'
-        assert result["sympy"] == "sqrt(162)"
+        assert result["latex"] == preview_latex
+        assert result["sympy"] == preview_sympy
 
     def test_handwritten_input(self):
         params = {

--- a/app/slr_quantity_tests.py
+++ b/app/slr_quantity_tests.py
@@ -223,6 +223,13 @@ slr_strict_si_syntax_test_cases = [
 ]
 
 slr_natural_si_syntax_test_cases = [
+    ("fs^4daA",
+     "fs^4daA",
+     None,
+     "fs^4daA",
+     r'A \cdot a \cdot d \cdot f \cdot s^{4}',
+     None,
+     ["NO_UNIT"]),
     ("mmPas",
      None,
      "mmPas",


### PR DESCRIPTION
E.g. m^3s was parsed as metre^(3second) instead of being treated as invalid