### PR TITLE
Fixed so that ! is accepted when strict_syntax is false

### DIFF
--- a/app/expression_utilities.py
+++ b/app/expression_utilities.py
@@ -579,9 +579,9 @@ def parse_expression(expr, parsing_params):
     expr = substitute(expr, substitutions)
     can_split = lambda x: False if x in unsplittable_symbols else _token_splittable(x)
     if strict_syntax:
-        transformations = parser_transformations[0:4]+extra_transformations
+        transformations = parser_transformations[0:5]+extra_transformations
     else:
-        transformations = parser_transformations[0:4, 6]+extra_transformations+(split_symbols_custom(can_split),)+parser_transformations[8]
+        transformations = parser_transformations[0:5, 6]+extra_transformations+(split_symbols_custom(can_split),)+parser_transformations[8]
     if parsing_params.get("rationalise", False):
         transformations += parser_transformations[11]
     if parsing_params.get("simplify", False):

--- a/app/symbolic_comparison_evaluation_tests.py
+++ b/app/symbolic_comparison_evaluation_tests.py
@@ -1041,5 +1041,15 @@ class TestEvaluationFunction():
         result = evaluation_function(response, answer, params)
         assert result["is_correct"] is value
 
+    def test_exclamation_mark_for_factorial(self):
+        response = "3!"
+        answer = "factorial(3)"
+        params = {
+            "strict_syntax": False,
+            "elementary_functions": True,
+        }
+        result = evaluation_function(response, answer, params)
+        assert result["is_correct"] is True
+
 if __name__ == "__main__":
     pytest.main(['-xsk not slow', "--tb=line", os.path.abspath(__file__)])


### PR DESCRIPTION
The cause of the bug was an off-by-one error which meant that the flag for allowing ! in parse_expr was not set.