### PR TITLE
Syntax for criteria using "where" added

### DIFF
--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -28,7 +28,7 @@ def evaluation_function(response, answer, params, include_test_data=False) -> di
     for input_symbol in params.get("input_symbols",[]):
         input_symbols_reserved_words += [input_symbol[0]]+input_symbol[1]
 
-    reserved_keywords = ["response", "answer", "plus_minus", "minus_plus"]
+    reserved_keywords = ["response", "answer", "plus_minus", "minus_plus", "where"]
     reserved_keywords_collisions = []
     for keyword in reserved_keywords:
         if keyword in input_symbols_reserved_words:

--- a/app/slr_parsing_utilities.py
+++ b/app/slr_parsing_utilities.py
@@ -19,6 +19,9 @@ def catch_undefined(label, content, original, start, end):
 
 
 # Syntax tree building utilities
+def proceed(production, output, tag_handler):
+    return output
+
 def package(production, output, tag_handler):
     label = production[0].label
     handle = production[1]
@@ -35,6 +38,14 @@ def append(production, output, tag_handler):
     children = output[1-len(handle):]
     output = output[0:(1-len(handle))]
     output[-1].children += children
+    return output
+
+
+def append_last(production, output, tag_handler):
+    handle = production[1]
+    last = output[-1]
+    output = output[0:(1-len(handle))]
+    output[-1].children.append(last)
     return output
 
 

--- a/app/symbolic_comparison_evaluation_tests.py
+++ b/app/symbolic_comparison_evaluation_tests.py
@@ -1101,6 +1101,9 @@ class TestEvaluationFunction():
                         'I': {'aliases': ['i'], 'latex': r'\(i\)'},
                     }
                 }),
+            ("3", "x+1", "response=answer where x=2", True, [], {}),
+            ("6", "x+y+1", "response=answer where x=2; y=3", True, [], {}),
+            ("15", "x+y*z+1", "response=answer where x=2; y=3; z=4", True, [], {}),
         ]
     )
     def test_criteria_based_comparison(self, response, answer, criteria, value, feedback_tags, additional_params):


### PR DESCRIPTION
Criteria of the form "A where B" is now supported. Note that the substitution is naive in the sense that we do not check that B only consists of proper definitions and that A can only be an equality, no other expression.