### PR TITLE
Changed behaviour for reserved keywords as input symbols

### DIFF
--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -44,7 +44,7 @@ def evaluation_function(response, answer, params, include_test_data=False) -> di
     eval_response = EvaluationResponse()
     eval_response.is_correct = False
 
-    input_symbols_reserved_words = list(params.get("symbols", dict()).keys())
+    input_symbols_reserved_words = []
 
     for input_symbol in params.get("symbols", dict()).values():
         input_symbols_reserved_words += input_symbol.get("aliases",[])
@@ -58,7 +58,10 @@ def evaluation_function(response, answer, params, include_test_data=False) -> di
         if keyword in input_symbols_reserved_words:
             reserved_keywords_collisions.append(keyword)
     if len(reserved_keywords_collisions) > 0:
-        raise Exception("`"+"`, `".join(reserved_keywords_collisions)+"` are reserved keyword and cannot be used as input symbol codes or alternatives.")
+        if len(reserved_keywords_collisions) == 1:
+            raise Exception("`"+"`, `".join(reserved_keywords_collisions)+"` is a reserved keyword and cannot be used as an input symbol alternative.")
+        else:
+            raise Exception("`"+"`, `".join(reserved_keywords_collisions)+"` are reserved keywords and cannot be used as input symbol alternatives.")
 
     parameters = {
         "comparison": "expression",

--- a/app/example_tests.py
+++ b/app/example_tests.py
@@ -57,12 +57,22 @@ class TestEvaluationFunction():
         params = {
             "strict_syntax": False,
             "elementary_functions": True,
+            "symbols": {
+                "plus_minus": {
+                    "latex": r"\(\pm\)",
+                    "aliases": ["pm","+-"],
+                },
+                "minus_plus": {
+                    "latex": r"\(\mp\)",
+                    "aliases": ["mp","-+"],
+                },
+            },
         }
-        preview = preview_function(response, params)["preview"]
-        result = evaluation_function(response, answer, params)
         # Checking latex output disabled as the function return a few different
         # variants of the latex in an unpredictable way
+        # preview = preview_function(response, params)["preview"]
         # assert preview["latex"] == response_latex
+        result = evaluation_function(response, answer, params)
         assert result["is_correct"] == True
 
     @pytest.mark.parametrize(

--- a/app/symbolic_comparison_evaluation_tests.py
+++ b/app/symbolic_comparison_evaluation_tests.py
@@ -985,30 +985,29 @@ class TestEvaluationFunction():
         result = evaluation_function(res, ans, params)
         assert result["is_correct"] is True
 
-    def test_no_reserved_keywords_in_input_symbol_codes(self):
+    def test_no_reserved_keywords_in_input_symbol_alternatives(self):
         reserved_keywords = ["response", "answer"]
         params = {
             "strict_syntax": False,
             "elementary_functions": True,
-        }
-        symbols = dict()
-        for keyword in reserved_keywords:
-            symbols.update(
-                {
-                    keyword: {
-                        "aliases": [],
-                        "latex": r"\mathrm{"+keyword+r"}"
-                    }
+            "symbols": {
+                "a": {
+                    "aliases": [reserved_keywords[0]],
+                    "latex": "a"
+                },
+                reserved_keywords[1]: {
+                    "aliases": ["b"],
+                    "latex": "b"
                 }
-            )
-        params.update({"symbols": symbols})
+            }
+        }
         response = "a+b"
         answer = "b+a"
         with pytest.raises(Exception) as e:
             evaluation_function(response, answer, params)
-        assert "`"+"`, `".join(reserved_keywords)+"`" in str(e.value)
+        assert reserved_keywords[0] in str(e.value)
 
-    def test_no_reserved_keywords_in_input_symbol_alternatives(self):
+    def test_reserved_keywords_in_input_symbol_codes(self):
         reserved_keywords = ["response", "answer"]
         params = {
             "strict_syntax": False,
@@ -1017,22 +1016,25 @@ class TestEvaluationFunction():
         symbols = dict()
         labels = list('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
         label_index = 0
-        for keyword in reserved_keywords:
-            symbols.update(
-                {
-                    labels[label_index]: {
-                        "aliases": [keyword],
-                        "latex": r"\mathrm{"+keyword+r"}"
-                    }
+        params = {
+            "strict_syntax": False,
+            "elementary_functions": True,
+            "symbols": {
+                reserved_keywords[0]: {
+                    "aliases": ["a"],
+                    "latex": "a"
+                },
+                reserved_keywords[1]: {
+                    "aliases": ["b"],
+                    "latex": "b"
                 }
-            )
-            label_index += 1
+            }
+        }
         params.update({"symbols": symbols})
         response = "a+b"
         answer = "b+a"
-        with pytest.raises(Exception) as e:
-            evaluation_function(response, answer, params)
-        assert "`"+"`, `".join(reserved_keywords)+"`" in str(e.value)
+        result = evaluation_function(response, answer, params)
+        assert result["is_correct"] is True
 
     def test_no_reserved_keywords_in_old_format_input_symbol_codes(self):
         reserved_keywords = ["response", "answer"]


### PR DESCRIPTION
Reserved keywords are now allowed as input symbol codes, but not input symbol alternatives