### PR TITLE
Found a case where generating a set was still necessary.

### DIFF
--- a/app/expression_utilities.py
+++ b/app/expression_utilities.py
@@ -67,7 +67,10 @@ special_symbols_names = [(x, []) for x in greek_letters]
 # -------- String Manipulation Utilities
 def create_expression_set(exprs, params):
     if isinstance(exprs, str):
-        exprs = [exprs]
+        if exprs.startswith('{') and exprs.endswith('}'):
+            exprs = [expr.strip() for expr in exprs[1:-1].split(',')]
+        else:
+            exprs = [exprs]
     expr_set = set()
     for expr in exprs:
         expr = substitute_input_symbols(expr, params)[0]

--- a/app/symbolic_comparison_preview_tests.py
+++ b/app/symbolic_comparison_preview_tests.py
@@ -96,8 +96,24 @@ class TestPreviewFunction():
         )
         result = preview_function(response, params)
         preview = result["preview"]
-        assert preview.get("sympy") == ' plus_minus 3*i/sqrt(5)'
+        assert preview.get("sympy") in {'{3*(sqrt(5)/5)*I, -3*sqrt(5)/5*I}', '{-3*sqrt(5)/5*I, 3*(sqrt(5)/5)*I}'}
         assert preview.get("latex") == r'\pm \frac{3}{\sqrt{5}} i'
+        response = r"4 \pm \sqrt{6}}"
+        params = Params(
+            is_latex=True,
+            simplify=False,
+            complexNumbers=True,
+            symbols={
+                "plus_minus": {
+                    "latex": "$\\pm$",
+                    "aliases": ["pm", "+-"],
+                },
+            }
+        )
+        result = preview_function(response, params)
+        preview = result["preview"]
+        assert preview.get("sympy") in {'{sqrt(6) + 4, 4 - sqrt(6)}', '{4 - sqrt(6), sqrt(6) + 4}'}
+        assert preview.get("latex") == r'4 \pm \sqrt{6}}'
 
     def test_latex_conversion_preserves_default_symbols(self):
         response = "\\mu + x + 1"


### PR DESCRIPTION
Non-set workaround did not work when expression only contained constant values and \pm. Simplified and improved generation and handling of set responses