### PR TITLE
Added replacement of `as` with `a s` to remove issues caused by `as` …

### DIFF
--- a/app/expression_utilities.py
+++ b/app/expression_utilities.py
@@ -268,13 +268,16 @@ def substitute_input_symbols(exprs, params):
         for code in input_symbols_to_remove:
             del input_symbols[code]
 
-    # Since 'lambda' is a reserved keyword in python
-    # it needs to be replaced with 'lamda' for expression
-    # parsing to work properly
+    # Since 'lambda' and 'as' are reserved keywords in python they
+    # have to be replaced for expression parsing to work properly
     lambda_value = input_symbols.pop("lambda", {"latex": r"\lambda", "aliases": ["lambda"]})
     if lambda_value is not None:
         lambda_value["aliases"].append("lambda")
     input_symbols.update({"lamda": lambda_value})
+    as_value = input_symbols.pop("as", {"latex": r"as", "aliases": ["as"]})
+    if as_value is not None:
+        as_value["aliases"].append("as")
+        input_symbols.update({"a s": as_value})
     params.update({"symbols": input_symbols})
 
     for (code, symbol_data) in input_symbols.items():

--- a/app/symbolic_comparison_evaluation_tests.py
+++ b/app/symbolic_comparison_evaluation_tests.py
@@ -1512,5 +1512,29 @@ class TestEvaluationFunction():
         result = evaluation_function(response, answer, params)
         assert result["is_correct"] is True
 
+    def test_as_in_expression(self):
+        response = "A/s(e^(-as)-e^(-bs))"
+        answer = "A/s(e^(-a*s)-e^(-b*s))"
+        params = {
+            "strict_syntax": False,
+            "elementary_functions": True,
+        }
+        result = evaluation_function(response, answer, params)
+        assert result["is_correct"] is True
+
+    def test_as_in_input_symbols(self):
+        response = "A/s(e^(-as)-e^(-bs))"
+        answer = "A/s(e^(-as)-e^(-bs))"
+        params = {
+            "strict_syntax": False,
+            "elementary_functions": True,
+            "symbols": {
+                "as": {"aliases": ["a_s"], "latex": r"$a_s$"},
+                "bs": {"aliases": ["b_s"], "latex": r"$b_s$"},
+            },
+        }
+        result = evaluation_function(response, answer, params)
+        assert result["is_correct"] is True
+
 if __name__ == "__main__":
     pytest.main(['-xk not slow', "--tb=line", '--durations=10', os.path.abspath(__file__)])


### PR DESCRIPTION
…being a python keyword

`as` is replaced by `a s` unless `as` is defined as an input symbol