### PR TITLE
Made all feedback start with a capital letter automatically.

### DIFF
--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -94,6 +94,20 @@ class TestEvaluationFunction():
         result = evaluation_function(response, answer, params)
         assert result["is_correct"] is False
 
+    def test_physical_qualities_correct_feedback(self):
+        params = {
+            "atol": 0.0,
+            "rtol": 0.0,
+            "strict_syntax": False,
+            "physical_quantity": True,
+            "elementary_functions": True,
+        }
+        response = "0.6 Nm"
+        answer = "0.6 Nm"
+        result = evaluation_function(response, answer, params)
+        assert result["is_correct"] is True
+        assert result["feedback"] == "Response matches answer."
+
     def test_euler_preview_evaluate(self):
         response = "ER_2"
         params = Params(is_latex=True, elementary_functions=False, strict_syntax=False)

--- a/app/tests/example_tests.py
+++ b/app/tests/example_tests.py
@@ -651,8 +651,8 @@ class TestEvaluationFunction():
                     "2+answer > response_UNKNOWN",
                 ],
                 {
-                    "answer <= response_TRUE": "AAA",
-                    "2+answer > response_UNKNOWN": "BBB",
+                    "answer <= response_TRUE": "Custom response true",
+                    "2+answer > response_UNKNOWN": "Custom response unknown",
                 },
                 {
                     "symbol_assumptions": "('x', 'real')",

--- a/app/tests/example_tests.py
+++ b/app/tests/example_tests.py
@@ -652,7 +652,7 @@ class TestEvaluationFunction():
                 ],
                 {
                     "answer <= response_TRUE": "Custom response true",
-                    "2+answer > response_UNKNOWN": "Custom response unknown",
+                    "2+answer > response_UNKNOWN": "μ Custom response unknown",
                 },
                 {
                     "symbol_assumptions": "('x', 'real')",

--- a/app/utility/evaluation_result_utilities.py
+++ b/app/utility/evaluation_result_utilities.py
@@ -38,6 +38,10 @@ class EvaluationResult:
                         feedback_string = graph.criteria[tag].feedback_string_generator(dict())
                     else:
                         feedback_string = graph.criteria[tag].feedback_string_generator(inputs)
+
+                if feedback_string is not None:
+                    feedback_string = feedback_string.capitalize()
+
                 self.add_feedback((tag, feedback_string))
 
     def add_criteria_graph(self, name, graph):

--- a/app/utility/evaluation_result_utilities.py
+++ b/app/utility/evaluation_result_utilities.py
@@ -39,7 +39,7 @@ class EvaluationResult:
                     else:
                         feedback_string = graph.criteria[tag].feedback_string_generator(inputs)
 
-                if feedback_string is not None:
+                if feedback_string is not None and feedback_string[0].isalpha() and feedback_string[0].isascii():
                     feedback_string = feedback_string.capitalize()
 
                 self.add_feedback((tag, feedback_string))


### PR DESCRIPTION
This is to fix the capitalisation of "response matches answer." feedback with Physical quantities.

As the feedback is generated from the tags "response matches answer_TRUE", etc. I decided it was easier and safer to "capitalise" (make the first letter of a string a capital) for all feedback strings, instead of this single tag, and to mitigate any problems where the tags are used elsewhere in the code base.