### PR TITLE
Bug/fix inappropriate symbol and ! for factorial

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
 # Base image that bundles AWS Lambda Python 3.8 image with some middleware functions
 # FROM base-eval-tmp
 # FROM rabidsheep55/python-base-eval-layer
-FROM ghcr.io/lambda-feedback/baseevalutionfunctionlayer:main-3.8
+FROM ghcr.io/lambda-feedback/baseevalutionfunctionlayer:main-3.12
 
 RUN yum install -y git
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,7 @@
 # FROM rabidsheep55/python-base-eval-layer
 FROM ghcr.io/lambda-feedback/baseevalutionfunctionlayer:main-3.12
 
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y git && dnf clean all
 
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -7,6 +7,8 @@ RUN dnf install -y git findutils && dnf clean all
 
 WORKDIR /app
 
+ENV PYTHONPATH=/app
+
 # Copy and install any packages/modules needed for your evaluation script.
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
@@ -57,4 +59,4 @@ RUN chmod 644 $(find . -type f)
 RUN chmod 755 $(find . -type d)
 
 # The entrypoint for AWS is to invoke the handler function within the app package
-CMD [ "/app/app.handler" ]
+CMD [ "app.handler" ]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,7 @@
 # FROM rabidsheep55/python-base-eval-layer
 FROM ghcr.io/lambda-feedback/baseevalutionfunctionlayer:main-3.12
 
-RUN yum install -y git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,7 @@
 # FROM rabidsheep55/python-base-eval-layer
 FROM ghcr.io/lambda-feedback/baseevalutionfunctionlayer:main-3.12
 
-RUN dnf install -y git && dnf clean all
+RUN dnf install -y git findutils && dnf clean all
 
 WORKDIR /app
 

--- a/app/context/symbolic.py
+++ b/app/context/symbolic.py
@@ -122,9 +122,11 @@ def check_equality(criterion, parameters_dict, local_substitutions=[]):
     elif not isinstance(lhs_expr, Equality) and isinstance(rhs_expr, Equality):
         result = False
     else:
-        # Subtraction of infinite values (e.g. oo - oo) yields nan rather than 0,
-        # so we use direct comparison when either side is infinite.
-        if lhs_expr.is_infinite or rhs_expr.is_infinite:
+        try:
+            either_is_infinite = lhs_expr.is_infinite or rhs_expr.is_infinite
+        except (KeyError, TypeError):
+            either_is_infinite = False
+        if either_is_infinite:
             result = do_comparison_infinite(criterion.content, lhs_expr, rhs_expr)
         else:
             result = do_comparison(criterion.content, lhs_expr-rhs_expr)

--- a/app/context/symbolic.py
+++ b/app/context/symbolic.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from sympy import Add, Pow, Mul, Equality, pi, im, I, N
+from sympy import Add, Pow, Mul, Equality, pi, im, I, N, oo
 from sympy import re as real_part
 
 from ..utility.expression_utilities import (
@@ -83,6 +83,22 @@ def create_expressions_for_comparison(criterion, parameters_dict, local_substitu
     return lhs_expr, rhs_expr
 
 
+def do_comparison_infinite(comparison_symbol, lhs_expr, rhs_expr):
+    # When either side is infinite, subtracting (e.g. oo - oo) yields nan, making
+    # the subtraction-based do_comparison unreliable. Compare the sides directly instead.
+    direct_comparisons = {
+        "=": lhs_expr == rhs_expr,
+        ">": lhs_expr > rhs_expr,
+        ">=": lhs_expr >= rhs_expr,
+        "<": lhs_expr < rhs_expr,
+        "<=": lhs_expr <= rhs_expr,
+    }
+    try:
+        return bool(direct_comparisons[comparison_symbol.strip()])
+    except Exception:
+        return None
+
+
 def do_comparison(comparison_symbol, expression):
     comparisons = {
         "=": lambda expr: bool(expression.cancel().simplify().simplify() == 0),
@@ -106,7 +122,12 @@ def check_equality(criterion, parameters_dict, local_substitutions=[]):
     elif not isinstance(lhs_expr, Equality) and isinstance(rhs_expr, Equality):
         result = False
     else:
-        result = do_comparison(criterion.content, lhs_expr-rhs_expr)
+        # Subtraction of infinite values (e.g. oo - oo) yields nan rather than 0,
+        # so we use direct comparison when either side is infinite.
+        if lhs_expr.is_infinite or rhs_expr.is_infinite:
+            result = do_comparison_infinite(criterion.content, lhs_expr, rhs_expr)
+        else:
+            result = do_comparison(criterion.content, lhs_expr-rhs_expr)
         # There are some types of expression, e.g. those containing hyperbolic trigonometric functions, that can behave
         # unpredictably when simplification is applied. For that reason we check several different combinations of
         # simplifications here in order to reduce the likelihood of false negatives.

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -294,6 +294,10 @@ def evaluation_function(response, answer, params, include_test_data=False) -> di
         if "!" in response:
             evaluation_result.add_feedback(("NOTATION_WARNING_FACTORIAL", symbolic_comparison_internal_messages("NOTATION_WARNING_FACTORIAL")(dict())))
 
+    if "!!!" in response:
+        evaluation_result.add_feedback(
+            ("NOTATION_WARNING_TRIPLE_FACTORIAL", symbolic_comparison_internal_messages("NOTATION_WARNING_TRIPLE_FACTORIAL")(dict())))
+
     reserved_expressions_success, reserved_expressions = parse_reserved_expressions(reserved_expressions_strings, parameters, evaluation_result)
     if reserved_expressions_success is False:
         return evaluation_result.serialise(include_test_data)

--- a/app/feedback/symbolic.py
+++ b/app/feedback/symbolic.py
@@ -21,6 +21,7 @@ feedback_generators["INTERNAL"] = lambda tag: lambda inputs: {
     "PARSE_ERROR": f"`{inputs.get('x','')}` could not be parsed as a valid mathematical expression. Ensure that correct codes for input symbols are used, correct notation is used, that the expression is unambiguous and that all parentheses are closed.",
     "NOTATION_WARNING_EXPONENT": "Note that `^` cannot be used to denote exponentiation, use `**` instead.",
     "NOTATION_WARNING_FACTORIAL": "Note that `!` cannot be used to denote factorial, use `factorial(...)` instead.",
+    "NOTATION_WARNING_TRIPLE_FACTORIAL": "Note that `!!!` is not supported.",
     "EXPRESSION_NOT_EQUALITY": "The response was an expression but was expected to be an equality.",
     "EQUALITY_NOT_EXPRESSION": "The response was an equality but was expected to be an expression.",
     "EQUALITIES_EQUIVALENT": None,

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 pydot
 typing_extensions
-mpmath==1.4.1
+mpmath==1.3.0
 sympy==1.14
 antlr4-python3-runtime==4.7.2
 git+https://github.com/lambda-feedback/latex2sympy.git@master#egg=latex2sympy2

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 pydot
 typing_extensions
 mpmath==1.2.1
-sympy==1.12
+sympy==1.13
 antlr4-python3-runtime==4.7.2
 git+https://github.com/lambda-feedback/latex2sympy.git@master#egg=latex2sympy2

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 pydot
 typing_extensions
-mpmath==1.2.1
-sympy==1.13
+mpmath==1.4.1
+sympy==1.14
 antlr4-python3-runtime==4.7.2
 git+https://github.com/lambda-feedback/latex2sympy.git@master#egg=latex2sympy2

--- a/app/tests/symbolic_evaluation_test.py
+++ b/app/tests/symbolic_evaluation_test.py
@@ -785,10 +785,6 @@ class TestEvaluationFunction():
                 '(0.002*6800*v)/1.2'
             ),
             (
-                '-∞',
-                '-inf'
-            ),
-            (
                 'x.y',
                 'x*y'
             ),
@@ -1935,6 +1931,11 @@ class TestEvaluationFunction():
         }
         result = evaluation_function(response, answer, params)
         assert result["is_correct"] is False
+
+    def test_infinity_unicode_symbol(self):
+        params = {'strict_syntax': True, 'elementary_functions': True}
+        result = evaluation_function('-∞', '-inf', params)
+        assert result["is_correct"] is True
 
     def test_infinity_alias(self):
         response = "2.694"

--- a/app/tests/symbolic_evaluation_test.py
+++ b/app/tests/symbolic_evaluation_test.py
@@ -1883,15 +1883,52 @@ class TestEvaluationFunction():
         result = evaluation_function(response, answer, params)
         assert result["is_correct"] is value
 
-    def test_exclamation_mark_for_factorial(self):
-        response = "3!"
-        answer = "factorial(3)"
+    @pytest.mark.parametrize(
+        "response, answer, value",
+        [
+            ("3!", "factorial(3)", True),
+            ("(n+1)!", "factorial(n+1)", True),
+            ("n!", "factorial(n)", True),
+            ("a!=b", "factorial(3)", False),
+            ("2*n!", "2*factorial(n)", True),
+            ("3!", "3!", True),
+            ("3*sin(n)!", "3*factorial(sin(n))", True)
+        ]
+    )
+    def test_exclamation_mark_for_factorial(self, response, answer, value):
         params = {
             "strict_syntax": False,
             "elementary_functions": True,
         }
         result = evaluation_function(response, answer, params)
-        assert result["is_correct"] is True
+        assert result["is_correct"] is value
+
+    @pytest.mark.parametrize(
+        "response, answer, value",
+        [
+            ("3!!", "factorial2(3)", True),
+            ("(n+1)!!", "factorial2(n+1)", True),
+            ("n!!", "factorial2(n)", True),
+            ("a!=b", "factorial2(3)", False),
+            ("2*n!!", "2*factorial2(n)", True),
+            ("3!!", "3!!", True),
+        ]
+    )
+    def test_double_exclamation_mark_for_factorial(self, response, answer, value):
+        params = {
+            "strict_syntax": False,
+            "elementary_functions": True,
+        }
+        result = evaluation_function(response, answer, params)
+        assert result["is_correct"] is value
+
+    def test_warning_for_triple_factorial(self):
+        answer = '2^4!'
+        response = '2^4!!!'
+        params = {'strict_syntax': False}
+        result = evaluation_function(response, answer, params, include_test_data=True)
+        assert result["is_correct"] is False
+        assert "NOTATION_WARNING_TRIPLE_FACTORIAL" in result["tags"]
 
     def test_alternatives_to_input_symbols_takes_priority_over_elementary_function_alternatives(self):
         answer = "Ef*exp(x)"

--- a/app/utility/expression_utilities.py
+++ b/app/utility/expression_utilities.py
@@ -62,7 +62,7 @@ elementary_functions_names = [
     ('acsch', ['arccsch', 'arccosech']), ('asech', ['arcsech']),
     ('exp', ['Exp']), ('E', ['e']), ('log', ['ln']),
     ('sqrt', []), ('sign', []), ('Abs', ['abs']), ('Max', ['max']), ('Min', ['min']), ('arg', []), ('ceiling', ['ceil']), ('floor', []),
-    ('oo',['Infinity', 'inf', 'infinity']),
+    ('oo',['Infinity', 'inf', 'infinity', '∞']),
     # Special symbols to make sure plus_minus and minus_plus are not destroyed during preprocessing
     ('plus_minus', []), ('minus_plus', []),
     # Below this line should probably not be collected with elementary functions. Some like 'common operations' would be a better name


### PR DESCRIPTION
**Requires #247 to be merged first before merging this PR.**

  Problem
  
  Two bugs affecting infinity and factorial handling in symbolic expression comparison:

  1. The Unicode infinity symbol (∞) was not recognised as valid input, causing parse errors when students used it.
  2. Comparing infinite expressions (e.g. oo = oo) would subtract the two sides before checking, but oo - oo evaluates to nan in SymPy rather than 0, causing incorrect results. A KeyError/TypeError could also be thrown during the is_infinite check.
  3. The triple factorial notation !!! was silently mishandled — it parses as repeated ! (factorial of factorial of factorial) rather than the mathematical triple factorial, with no warning to the student.

  Fix

  - Added ∞ as an alias for oo in expression_utilities.py so the Unicode symbol is accepted as input.
  - Added do_comparison_infinite in context/symbolic.py that compares infinite expressions directly (e.g. lhs == rhs) instead of via subtraction, and wrapped the is_infinite check in a try/except to guard against edge-case exceptions.
  - Added a NOTATION_WARNING_TRIPLE_FACTORIAL feedback message and wired it up in evaluation.py to warn students that !!! is not supported.

  Other changes

  - Upgraded to Python 3.12, SymPy 1.14, and mpmath 1.4.1; updated CI workflows accordingly.
  - Fixed the Dockerfile: switched base image package manager, added find to installed requirements, set PYTHONPATH, and updated the CMD entrypoint format.
