### PR TITLE
Fix/strict syntax default

### DIFF
--- a/app/docs/user.md
+++ b/app/docs/user.md
@@ -240,7 +240,7 @@ If `strict_syntax` is set to true then the answer and response must have `*` or 
 
 If `strict_syntax` is set to false, then `*` can be omitted and `^` used instead of `**`. In this case it is also recommended to list any multicharacter symbols expected to appear in the response as input symbols.
 
-By default `strict_syntax` is set to true.
+By default `strict_syntax` is set to false.
 
 #### `symbol_assumptions`
 

--- a/app/evaluation.py
+++ b/app/evaluation.py
@@ -288,7 +288,7 @@ def evaluation_function(response, answer, params, include_test_data=False) -> di
         )
 
     # FIXME: Move this into expression_utilities
-    if params.get("strict_syntax", True):
+    if params.get("strict_syntax", False):
         if "^" in response:
             evaluation_result.add_feedback(("NOTATION_WARNING_EXPONENT", symbolic_comparison_internal_messages("NOTATION_WARNING_EXPONENT")(dict())))
         if "!" in response:

--- a/app/evaluation_test.py
+++ b/app/evaluation_test.py
@@ -192,6 +192,26 @@ class TestEvaluationFunction():
 
 
 
+    @pytest.mark.parametrize("params, is_correct", [
+        ({}, True),
+        ({"atol": 0.0, "rtol": 0.0, "strict_syntax": False, "physical_quantity": False, "elementary_functions": False}, True),
+        ({"atol": 0.0, "rtol": 0.0, "strict_syntax": False, "physical_quantity": False, "elementary_functions": True}, True),
+        ({"atol": 0.0, "rtol": 0.0, "strict_syntax": True,  "physical_quantity": False, "elementary_functions": False}, False),
+        ({"atol": 0.0, "rtol": 0.0, "strict_syntax": True,  "physical_quantity": False, "elementary_functions": True}, False),
+    ])
+    def test_strict_syntax_rejects_implicit_multiplication(self, params, is_correct):
+        response = "-2M0/3"
+        answer = "-2M0/3"
+        if is_correct:
+            result = evaluation_function(response, answer, params)
+            assert result["is_correct"] is True
+        else:
+            # strict_syntax=True prevents implicit multiplication, so -2M0/3 cannot be
+            # parsed. Answer parse failures are raised as exceptions (not returned as
+            # is_correct=False) because they indicate a task misconfiguration.
+            with pytest.raises(Exception):
+                evaluation_function(response, answer, params)
+
     def test_mu_preview_evaluate(self):
         response = "10 μA"
         params = Params(is_latex=False, elementary_functions=False, strict_syntax=False, physical_quantity=True)

--- a/app/tests/symbolic_evaluation_test.py
+++ b/app/tests/symbolic_evaluation_test.py
@@ -227,7 +227,7 @@ class TestEvaluationFunction():
         answer = "3x"
         e = None
         with pytest.raises(Exception) as e:
-            evaluation_function(response, answer, {})
+            evaluation_function(response, answer, {"strict_syntax": True})
         assert e is not None
 
     @pytest.mark.parametrize(

--- a/app/utility/expression_utilities.py
+++ b/app/utility/expression_utilities.py
@@ -671,7 +671,7 @@ def create_sympy_parsing_params(params, unsplittable_symbols=tuple(), symbol_ass
 
     symbol_dict.update(sympy_symbols(unsplittable_symbols))
 
-    strict_syntax = params.get("strict_syntax", True)
+    strict_syntax = params.get("strict_syntax", False)
 
     parsing_params = {
         "unsplittable_symbols": unsplittable_symbols,

--- a/app/utility/expression_utilities.py
+++ b/app/utility/expression_utilities.py
@@ -9,7 +9,7 @@ default_parameters = {
     "complexNumbers": False,
     "convention": "equal_precedence",
     "elementary_functions": False,
-    "strict_syntax": True,
+    "strict_syntax": False,
     "multiple_answers_criteria": "all",
 }
 


### PR DESCRIPTION
 **Problem**

 The platform sets strict_syntax to false by default, but the code defaulted to True in two places (evaluation.py and expression_utilities.py). This meant that when no strict_syntax key was present in params, the code would enforce strict syntax rules (e.g. rejecting ^ for exponentiation) even though the platform's intended behaviour is to be permissive by default.

  **Fix**

  Changed the fallback value for params.get("strict_syntax", ...) from True to False in both:
  - app/evaluation.py — controls the ^ and ! notation warnings
  - app/utility/expression_utilities.py — controls the SymPy parsing strictness

  **Other changes**

  None — this is a targeted two-line fix with no refactoring or behaviour changes beyond aligning the defaults.


**Database Testing**
Results can be found here: https://github.com/lambda-feedback/compareExpressions/actions/runs/25863534753/job/75999407423

10 errors out of 1000

1. _`(x cosx - sinx) / (x^{2})` could not be parsed as a valid mathematical expression. Ensure that correct codes for input symbols are used, correct notation is used, that the expression is unambiguous and that all parentheses are closed._
  - Answer is written in LaTeX
2. _Grade mismatch: - Eval function: True, DB: False -- answer: `d/(dt)+ujd/(dxj)` response: `d/(dt)+uj(d/(dxj))`_
  - The answer and the response match
3. _`2( tan x) sec^(2) x` could not be parsed as a valid mathematical expression. Ensure that correct codes for input symbols are used, correct notation is used, that the expression is unambiguous and that all parentheses are closed._
   - Same as 1.
4. _Grade mismatch: - Eval function: True, DB: False -- answer: `(1/3)*beta*gamma*z**3 + (1/2)*(rho_0*gamma + beta*g_0)*z**2 + rho_0*g_0*z` response: `1/3 beta gammaz^3+1/2(rho_0 gamma)z^2+1/2(g_0 beta)z^2+(rho_0g_0)z`_
  - The answer and response match
5. _Grade mismatch: - Eval function: True, DB: False -- answer: `(d/(dt)+ujd/(dxj)` response: `d/(dt)+uj*((d/(dxj)))`_
  - The answer and response match
6. _Grade mismatch: - Eval function: True, DB: False -- answer: `(d/(dt)+ujd/(dxj)` response: `d/(dt)+uj*((d/(dxj)))`_
  - The answer and response match
7. _`x E^{x}(2+x)` could not be parsed as a valid mathematical expression. Ensure that correct codes for input symbols are used, correct notation is used, that the expression is unambiguous and that all parentheses are closed._
  - Answer is written in LaTeX
8. _Grade mismatch: - Eval function: True, DB: False -- answer: `A/s( e^(-as)-e^(-bs))` response: `A(( E^(-a*s))-( E^(-b*s)))/s`_
  - The answer and response match
9. _`2( tan x) sec^(2) x` could not be parsed as a valid mathematical expression. Ensure that correct codes for input symbols are used, correct notation is used, that the expression is unambiguous and that all parentheses are closed._
  - Answer written in LaTeX
10. _`-2M0/3` could not be parsed as a valid mathematical expression. Ensure that correct codes for input symbols are used, correct notation is used, that the expression is unambiguous and that all parentheses are closed._
 - Parsing issue when no parameters are included, not due to this change.
