### PR TITLE
Fix/sum preview

### DIFF
--- a/app/preview_test.py
+++ b/app/preview_test.py
@@ -273,6 +273,47 @@ class TestPreviewFunction():
         assert result["preview"]["latex"] == latex
         assert result["preview"]["sympy"] == sympy
 
+    @pytest.mark.parametrize(
+        "response, latex, sympy", [
+            # summation() with explicit bounds — rendered correctly by SymPy
+            (
+                'summation((4/n**2)(-1)**n cos(nx), (n, 1, oo))',
+                r'\sum_{n=1}^{\infty} \frac{4 \cdot \left(-1\right)^{n} \cdot \cos{\left(n \cdot x \right)}}{n^{2}}',
+                'summation((4/n**2)(-1)**n cos(nx), (n, 1, oo))',
+            ),
+            # infsum as a custom prefix symbol — content must appear inside the sum, not outside
+            (
+                'infsum((-1)^n / n^2)',
+                r'\sum_{n=1}^{\infty} \frac{\left(-1\right)^{n}}{n^{2}}',
+                'infsum((-1)^n / n^2)',
+            ),
+            (
+                'infsum((4/n^2)*(-1)^n*cos(nx))',
+                r'\sum_{n=1}^{\infty} \frac{4 \cdot \left(-1\right)^{n} \cdot \cos{\left(n \cdot x \right)}}{n^{2}}',
+                'infsum((4/n^2)*(-1)^n* cos(nx))',
+            ),
+            (
+                '((pi^2)/(3))+infsum((4/n^2)*(-1)^n*cos(nx))',
+                r'\frac{\pi^{2}}{3} + \sum_{n=1}^{\infty} \frac{4 \cdot \left(-1\right)^{n} \cdot \cos{\left(n \cdot x \right)}}{n^{2}}',
+                '(( pi^2)/(3))+infsum((4/n^2)*(-1)^n* cos(nx))',
+            ),
+        ]
+    )
+    def test_sum_preview(self, response, latex, sympy):
+        params = {
+            "is_latex": False,
+            "strict_syntax": False,
+            "elementary_functions": True,
+            "symbols": {
+                "infsum": {"aliases": [], "latex": "\\sum_{n=1}^{\\infty}"},
+                "pi": {"aliases": [], "latex": "\\pi"},
+            },
+        }
+
+        result = preview_function(response, params)
+        assert result["preview"]["latex"] == latex
+        assert result["preview"]["sympy"] == sympy
+
 
 
 if __name__ == "__main__":

--- a/app/utility/expression_utilities.py
+++ b/app/utility/expression_utilities.py
@@ -561,22 +561,33 @@ symbol_latex_re = re.compile(
     r"(?P<start>\\\(|\$\$|\$)(?P<latex>.*?)(?P<end>\\\)|\$\$|\$)"
 )
 
+BIG_OPERATOR_PREFIXES = (r"\sum", r"\int", r"\prod", r"\lim", r"\bigcup", r"\bigcap")
+
 
 def sympy_symbols(symbols):
     """Create a mapping of local variables for parsing sympy expressions.
 
     Args:
         symbols (SymbolDict): A dictionary of sympy symbol strings to LaTeX
-        symbol strings.
-
-    Note:
-        Only the sympy string is used in this function.
+        symbol strings, or an iterable of symbol name strings.
 
     Returns:
-        Dict[str, Symbol]: A dictionary of sympy symbol strings to sympy
-        Symbol objects.
+        Dict[str, Symbol | type]: A dictionary mapping symbol names to SymPy
+        Symbol objects, or to Function subclasses for prefix operator symbols
+        (those whose latex begins with a big operator command like \\sum).
     """
-    return {k: Symbol(k) for k in symbols}
+    result = {}
+    for k in symbols:
+        symbol_def = symbols[k] if isinstance(symbols, dict) else None
+        if isinstance(symbol_def, dict):
+            latex = extract_latex(symbol_def.get("latex", "")).strip()
+            if any(latex.startswith(op) for op in BIG_OPERATOR_PREFIXES):
+                def _latex(self, printer, _l=latex):
+                    return _l + " " + printer.doprint(self.args[0])
+                result[k] = type(k, (Function,), {"_latex": _latex})
+                continue
+        result[k] = Symbol(k)
+    return result
 
 
 def extract_latex(symbol):
@@ -684,6 +695,8 @@ def create_sympy_parsing_params(params, unsplittable_symbols=tuple(), symbol_ass
     }
 
     symbol_dict.update(sympy_symbols(unsplittable_symbols))
+    if "symbols" in params:
+        symbol_dict.update(sympy_symbols(params["symbols"]))
 
     strict_syntax = params.get("strict_syntax", False)
 

--- a/app/utility/expression_utilities.py
+++ b/app/utility/expression_utilities.py
@@ -695,8 +695,6 @@ def create_sympy_parsing_params(params, unsplittable_symbols=tuple(), symbol_ass
     }
 
     symbol_dict.update(sympy_symbols(unsplittable_symbols))
-    if "symbols" in params:
-        symbol_dict.update(sympy_symbols(params["symbols"]))
 
     strict_syntax = params.get("strict_syntax", False)
 


### PR DESCRIPTION
Problem:
 Custom symbols defined with big-operator LaTeX (e.g. `infsum` with `\sum_{n=1}^{\infty}`) were treated as plain SymPy Symbol objects. This meant `infsum((-1)^n / n^2)` parsed as multiplication (`Symbol("infsum") * ((-1)^n / n^2)`), causing the sum symbol to appear in fraction numerators or with spurious `\cdot` multiply dots in the preview. For example, from JF's [course](https://www.lambdafeedback.com/PHYS40003_O_W_Fourier/instances/2025_26/sets/aac55976-1388-480f-8d0b-2281757731d5?question_id=64976884-c53a-4e63-b24f-07a79cdc653b):

  - `infsum((-1)^n / n^2)` rendered with the sum symbol inside the fraction numerator instead of wrapping the expression
  - `pi^2/3 + infsum((-1)^n*cos(n*x)*(4/n^2)` rendered with a \cdot immediately after the sum symbol

<img width="935" height="436" alt="image005" src="https://github.com/user-attachments/assets/d59aa617-c279-48df-bd7a-57f09c9346ad" />



Solution:
Detect prefix operator symbols automatically from their existing `latex` definition: if a symbol's LaTeX starts with a big operator command (`\sum, \int, \prod, \lim, \bigcup, \bigcap`), create a SymPy Function subclass for it instead of a Symbol. No changes to teacher-facing configuration are required.

 A SymPy Function subclass is necessary because of how SymPy's parser handles callable objects in `local_dict`. When `infsum` is a Symbol, SymPy's auto-multiplication transformation converts `infsum(x)` into `Symbol("infsum") * x`.
 
By placing a Function subclass in `local_dict` instead, SymPy's parser treats `infsum(x)` as a genuine function application `InfSum(x)`, the subclass carries a `_latex()` method that the Sy
mPy printer calls when it encounters `InfSum(x)`, returning
  `{symbol_latex} {arg_latex`} directly.
  
  Changes:
  - `app/utility/expression_utilities.py` - added BIG_OPERATOR_PREFIXES constant; modified `sympy_symbols()` to create a dynamic Function subclass (with custom `_latex()`) for any symbol whose LaTeX begins with a big operator prefix, falling back to Symbol otherwise.
  - `app/preview_test.py` - added test_sum_preview 

To test please use the sandbox [here](https://staging.lambdafeedback.com/teacher/modules/8a546cda-f171-4e5b-af79-74df64efeaeb/instances/b0c408d9-58cc-42bf-a012-3ff968c95c99/sets/3575b5ad-ee28-4774-981c-96a551148199?question_id=0c7cf078-63a0-4f3f-981a-b764d960002d)