### PR TITLE
Fix/atol rtol alignment

### DIFF
--- a/app/context/physical_quantity.py
+++ b/app/context/physical_quantity.py
@@ -282,10 +282,9 @@ def criterion_match_node(criterion, parameters, label=None):
                     ans = parameters["reserved_expressions"]["answer"]["standard"]["value"].simplify()
                     res = parameters["reserved_expressions"]["response"]["standard"]["value"].simplify()
                 if (ans is not None and ans.is_constant()) and (res is not None and res.is_constant()):
-                    if parsing_params.get('rtol', 0) > 0 and (ans != 0):
-                        value_match = bool(abs(float((ans-res)/ans)) < parsing_params['rtol'])
-                    elif parsing_params.get('atol', 0) > 0 or (ans == 0):
-                        value_match = bool(abs(float(ans-res)) < parsing_params['atol'])
+                    atol = float(parsing_params.get('atol', 0))
+                    rtol = float(parsing_params.get('rtol', 0))
+                    value_match = bool(abs(float(ans - res)) <= atol + rtol * abs(float(ans)))
 
         substitutions = [(key, expr["standard"]["unit"]) for (key, expr) in reserved_expressions]
         unit_match = is_equal(lhs, rhs, substitutions)

--- a/app/context/symbolic.py
+++ b/app/context/symbolic.py
@@ -142,8 +142,6 @@ def check_equality(criterion, parameters_dict, local_substitutions=[]):
 
         # TODO: Make numerical comparison its own context
         if result is False:
-            error_below_rtol = None
-            error_below_atol = None
             if parameters_dict.get("numerical", False) or float(parameters_dict.get("rtol", 0)) > 0 or float(parameters_dict.get("atol", 0)) > 0:
                 # REMARK: 'pi' should be a reserved symbol but it is sometimes not treated as one, possibly because of input symbols.
                 # The two lines below this comments fixes the issue but a more robust solution should be found for cases where there
@@ -158,26 +156,22 @@ def check_equality(criterion, parameters_dict, local_substitutions=[]):
                 # Separates LHS and RHS, parses and evaluates them
                 res = N(replace_pi(lhs_expr))
                 ans = N(replace_pi(rhs_expr))
-                if float(parameters_dict.get("atol", 0)) > 0:
+
+                atol = float(parameters_dict.get("atol", 0))
+                rtol = float(parameters_dict.get("rtol", 0))
+
+                try:
+                    # Dividing by ans cancels symbols (e.g. rho*L^3 / rho*L^3 = 1)
+                    # Equivalent to numpy.isclose: |ans-res| <= atol + rtol*|ans|
+                    ratio = float((ans - res) / ans)
                     try:
-                        absolute_error = abs(float(ans-res))
-                        error_below_atol = bool(absolute_error < float(parameters_dict["atol"]))
+                        tolerance = rtol + atol / abs(float(ans))
                     except TypeError:
-                        error_below_atol = None
-                else:
-                    error_below_atol = True
-                if float(parameters_dict.get("rtol", 0)) > 0:
-                    try:
-                        relative_error = abs(float((ans-res)/ans))
-                        error_below_rtol = bool(relative_error < float(parameters_dict["rtol"]))
-                    except TypeError:
-                        error_below_rtol = None
-                else:
-                    error_below_rtol = True
-                if error_below_atol is None or error_below_rtol is None:
+                        # Defaulting to relative tolerance if symbol cancellation fails to preserve the previous implementation
+                        tolerance = rtol
+                    result = bool(abs(ratio) <= tolerance)
+                except (TypeError, ZeroDivisionError):
                     result = False
-                elif error_below_atol is True and error_below_rtol is True:
-                    result = True
 
     return result
 


### PR DESCRIPTION
Problem: The atol and rtol tolerance checks in the symbolic and physical quantity evaluators used inconsistent, non-standard logic: they treated atol and rtol as separate independent conditions (both had to pass), used the answer as the rtol reference in some places and the response in others, and used strict < rather than <=.
  
 Solution: Align both evaluators with NumPy's isclose formula: |ans - res| <= atol + rtol * |ans|, where ans is the reference value. This combines atol and rtol into a single tolerance bound, matches the behaviour users familiar with NumPy would expect, and is consistent with isSimilar in other tools.

  Changes:
  - app/context/symbolic.py: Replaced the separate atol/rtol checks with the combined NumPy formula. The division-by-ans form (|(ans-res)/ans| <= rtol + atol/|ans|) is used to handle expressions with symbols (e.g. rho*L^3). Falls back to rtol-only tolerance if |ans| itself cannot be evaluated (e.g. answer is still partially symbolic).
  - app/context/physical_quantity.py: Replaced the rtol-or-atol branching logic with the same combined NumPy formula. The direct form is used here since the is_constant() guard guarantees both sides are fully numeric before the comparison runs.
