### PR TITLE
Fix physical quantitiy handdrawn latex

### DIFF
--- a/app/preview_implementations/physical_quantity_preview.py
+++ b/app/preview_implementations/physical_quantity_preview.py
@@ -1,3 +1,4 @@
+import tokenize
 from copy import deepcopy
 
 from ..utility.expression_utilities import (
@@ -119,7 +120,7 @@ def preview_function(response: str, params: Params) -> Result:
             latex_out = res_parsed.latex_string
             sympy_out = response
 
-    except SyntaxError as e:
+    except (SyntaxError, tokenize.TokenError) as e:
         raise Exception("Failed to parse Sympy expression") from e
     except ValueError as e:
         raise Exception("Failed to parse LaTeX expression") from e

--- a/app/preview_test.py
+++ b/app/preview_test.py
@@ -274,6 +274,5 @@ class TestPreviewFunction():
         assert result["preview"]["sympy"] == sympy
 
 
-
 if __name__ == "__main__":
     pytest.main(['-xk not slow', "--tb=line", os.path.abspath(__file__)])

--- a/app/tests/physical_quantity_preview_test.py
+++ b/app/tests/physical_quantity_preview_test.py
@@ -89,6 +89,23 @@ class TestPreviewFunction():
         assert result["latex"] == r'162~\frac{\mathrm{newton}}{\mathrm{metre}^{(2)}}'  # TODO: Fix so that unnecessary parenthesis are simplified away
         assert result["sympy"] == "162 newton/metre**(2)"
 
+    @pytest.mark.parametrize(
+        "response, latex, sympy", [
+            (r"\frac{F}{p \cdot \mu}", r"\frac{F}{\mu p}", "F/((mu*p))"),
+            (r"F \cdot p", "F p", "F*p"),
+            (r"\frac{10}{2} \mathrm{~kg}", r"\frac{10}{2}~\mathrm{kilogram}", "10/2 kilogram"),
+        ]
+    )
+    def test_latex_physical_quantity_preview(self, response, latex, sympy):
+        params = {
+            "is_latex": True,
+            "physical_quantity": True,
+            "elementary_functions": True,
+        }
+        result = preview_function(response, params)["preview"]
+        assert result["latex"] == latex
+        assert result["sympy"] == sympy
+
 
 if __name__ == "__main__":
     pytest.main(['-xk not slow', "--tb=line", os.path.abspath(__file__)])

--- a/app/utility/physical_quantity_utilities.py
+++ b/app/utility/physical_quantity_utilities.py
@@ -22,6 +22,7 @@ from .unit_system_conversions import\
 from ..feedback.physical_quantity import feedback_string_generators as physical_quantity_feedback_string_generators
 
 from ..preview_implementations.symbolic_preview import preview_function as symbolic_preview
+from .preview_utilities import parse_latex
 
 QuantityTags = Enum("QuantityTags", {v: i for i, v in enumerate("UVNR", 1)})
 
@@ -209,6 +210,10 @@ class PhysicalQuantity:
     def _all_forms(self):
         parsing_params = self.parsing_params
         converted_value = self.value.content_string() if self.value is not None else None
+
+        if converted_value is not None and self.parameters.get("is_latex", False):
+            symbols = self.parameters.get("symbols", {})
+            converted_value = parse_latex(converted_value, symbols, self.parameters.get("simplify", False))
         converted_unit = None
         expanded_unit = None
         converted_dimension = parse_expression("1", parsing_params)


### PR DESCRIPTION
## Problem
Previewing a physical-quantity LaTeX expression whose value contains LaTeX syntax, such as when from hand-drawn maths.

When previewing `\frac{x}{y} kg` in compareExpressions with `physical _quantity` enabled, the value (`\frac{x}{y}`) will be parsed directly by sympy instead of parsing via LaTeX first, causing the preview function to throw an exception. 

## Changes

- `app/utility/physical_quantity_utilities.py`: `PhysicalQuantity._all_forms()` now converts the value string through `parse_latex()` before parsing it with SymPy, guarded by `is_latex`, mirroring the existing conversion pattern used in `physical_quantity_preview.py`.
- `app/preview_implementations/physical_quantity_preview.py`: also catch `tokenize.TokenError` alongside `SyntaxError` so any other not-yet-found unconvertible-LaTeX edge case are handled correctly
- `app/tests/physical_quantity_preview_test.py`: added `test_latex_physical_quantity_preview`, to test various inputs for preview