### PR TITLE
Fix unbalanced parenthesis error in 'written as' criteria

### DIFF
--- a/app/tests/symbolic_evaluation_test.py
+++ b/app/tests/symbolic_evaluation_test.py
@@ -1644,6 +1644,50 @@ class TestEvaluationFunction():
                 ],
                 {"detailed_feedback": True}
             ),
+            # Regression test: "response written as answer" used to raise
+            # `re.error: unbalanced parenthesis` whenever the last number in
+            # `answer` was not immediately followed by more digits, e.g. a
+            # trailing closing bracket, since the tail of the string after the
+            # final matched number was not escaped/wrapped before being
+            # inserted into the generated regex pattern.
+            (
+                "(2x-5)(3x+2)",
+                "(2x-5)(3x+2)",
+                "response = answer, response written as answer",
+                True,
+                [
+                    "answer_WRITTEN_AS_UNKNOWN",
+                    "response = answer_TRUE",
+                    "response = answer_SAME_SYMBOLS_TRUE",
+                    "response written as answer_TRUE"
+                ],
+                {"detailed_feedback": True}
+            ),
+            (
+                "(3x+2)(2x-5)",
+                "(2x-5)(3x+2)",
+                "response = answer, response written as answer",
+                False,
+                [
+                    "answer_WRITTEN_AS_UNKNOWN",
+                    "response = answer_TRUE",
+                    "response = answer_SAME_SYMBOLS_TRUE",
+                    "response written as answer_FALSE"
+                ],
+                {"detailed_feedback": True}
+            ),
+            (
+                "3x^2-11x-10",
+                "(2x-5)(3x+2)",
+                "response = answer, response written as answer",
+                False,
+                [
+                    "answer_WRITTEN_AS_UNKNOWN",
+                    "response = answer_FALSE",
+                    "response written as answer_FALSE"
+                ],
+                {"detailed_feedback": True}
+            ),
         ]
     )
     def test_syntactical_comparison(self, response, answer, criteria, value, feedback_tags, additional_params):

--- a/app/tests/syntactical_comparison_utilities_test.py
+++ b/app/tests/syntactical_comparison_utilities_test.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ..utility.syntactical_comparison_utilities import generate_arbitrary_number_pattern_matcher
+
+
+class TestGenerateArbitraryNumberPatternMatcher:
+
+    @pytest.mark.parametrize(
+        "pattern_string, matching_strings, non_matching_strings",
+        [
+            ("2x+3", ["2x+3", "5x+7"], ["2x-3", "2x+3+1"]),
+            # Regression test: the text following the last matched number
+            # (here the closing bracket ")") used to be inserted into the
+            # generated regex unescaped and unwrapped, which could produce
+            # an invalid pattern and raise `re.error: unbalanced parenthesis`.
+            ("(2x-5)(3x+2)", ["(2x-5)(3x+2)", "(7x-1)(4x+9)"], ["(3x+2)(2x-5)", "3x^2-11x-10"]),
+            ("(x-4)^2-5", ["(x-4)^2-5", "(x-6)^2-1"], ["(x-4)^2+5", "x^2-8x+11"]),
+        ]
+    )
+    def test_matcher(self, pattern_string, matching_strings, non_matching_strings):
+        matcher = generate_arbitrary_number_pattern_matcher(pattern_string)
+        for matching_string in matching_strings:
+            assert matcher(matching_string) is True
+        for non_matching_string in non_matching_strings:
+            assert matcher(non_matching_string) is False

--- a/app/utility/syntactical_comparison_utilities.py
+++ b/app/utility/syntactical_comparison_utilities.py
@@ -64,7 +64,11 @@ def generate_arbitrary_number_pattern_matcher(string):
         offset = end
         number = re.search(number_pattern, string[offset:])
         nonneg_number = re.search(nonneg_number_pattern, string[offset:])
-    non_numbers.append(string[offset:])
+    tail = escape_regex_reserved_characters(string[offset:])
+    if len(tail) > 0:
+        tail = '('+tail+')'
+    tail = ''.join(tail.split())
+    non_numbers.append(tail)
     pattern = full_pattern.join(non_numbers)
 
     def matcher(comp_string):


### PR DESCRIPTION
## Summary
- Fixes a bug where the `written as` criteria (e.g. `response = answer, response written as answer`) raised `re.error: unbalanced parenthesis` for expressions like `(2x-5)(3x+2)`.
- Root cause: `generate_arbitrary_number_pattern_matcher` in `app/utility/syntactical_comparison_utilities.py` escapes and parenthesizes the text between matched numbers while building its regex pattern, but the trailing text *after* the last matched number was appended raw — unescaped and unwrapped. For `(2x-5)(3x+2)` the trailing `)` was spliced directly into the generated regex, breaking it.
- Applies the same escape/wrap treatment to the trailing tail as is already used for every other gap in the pattern.

## Test plan
- [x] Added regression cases to `test_syntactical_comparison` in `app/tests/symbolic_evaluation_test.py` reproducing the exact bug-report request, plus a same-but-reordered and an expanded-form variant covering the True/False branches.
- [x] Added `app/tests/syntactical_comparison_utilities_test.py` with direct unit tests for `generate_arbitrary_number_pattern_matcher`.
- [x] `pytest app/tests/symbolic_evaluation_test.py` — 813 passed.
- [x] `pytest app/tests` — 1637 passed, 2 skipped.
- [x] Manually confirmed the original bug-report request now returns `is_correct: True` with no exception.

https://claude.ai/code/session_015ZMMVQrgdbDgabqMnumoYw